### PR TITLE
Add URL preview image functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -200,6 +200,21 @@ button:hover {
   white-space: pre-wrap;
 }
 
+.recipe-preview-image {
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: 8px;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+  cursor: pointer;
+  object-fit: cover;
+  transition: transform 0.2s ease;
+}
+
+.recipe-preview-image:hover {
+  transform: scale(1.02);
+}
+
 .recipe-image {
   max-width: 100%;
   border-radius: 8px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -239,6 +239,23 @@ function App() {
                   ) : (
                     <strong className="recipe-title">{recipe.title || 'Untitled'}</strong>
                   )}
+                  {recipe.previewImage && (
+                    <img
+                      src={recipe.previewImage}
+                      alt={recipe.title || 'Recipe preview'}
+                      className="recipe-preview-image"
+                      onError={(e) => {
+                        e.target.style.display = 'none';
+                      }}
+                      onClick={() => {
+                        setScrollPosition(window.scrollY);
+                        setZoomedImage({
+                          src: recipe.previewImage,
+                          alt: recipe.title || 'Recipe preview'
+                        });
+                      }}
+                    />
+                  )}
                   {recipe.url && (
                     <a href={recipe.url} target="_blank" rel="noopener noreferrer" className="recipe-url">
                       {recipe.url}


### PR DESCRIPTION
Implements URL preview images for recipe app

- Extract OpenGraph/Twitter card images from URLs in worker
- Display preview images between title and URL for URL recipes
- Add CSS styling with hover effects and error handling
- Support relative and absolute URL resolution

Fixes #2

Generated with [Claude Code](https://claude.ai/code)