### PR TITLE
Add screen for viewing and restoring deleted recipes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -433,6 +433,12 @@ button:hover {
   transform: translateY(-1px);
 }
 
+.undelete-btn:disabled {
+  background: #6c757d;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .edit-btn {
   background: transparent;
   color: #666;

--- a/src/App.css
+++ b/src/App.css
@@ -369,3 +369,91 @@ button:hover {
 .cancel-btn:hover {
   background-color: #5a6268;
 }
+
+/* ========== Deleted Recipes Styles ========== */
+.top-buttons {
+  display: flex;
+  gap: 1em;
+  margin-bottom: 1em;
+  align-items: center;
+}
+
+.toggle-deleted-button {
+  background: transparent;
+  color: white;
+  border: 2px solid white;
+  padding: 0.75em 1.5em;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1em;
+  transition: all 0.2s ease;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.toggle-deleted-button:hover {
+  background: white;
+  color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.toggle-deleted-button.active {
+  background: white;
+  color: var(--primary);
+}
+
+.recipe-item.deleted {
+  opacity: 0.7;
+  border-color: #ccc;
+  background: #f8f8f8;
+}
+
+.recipe-item.deleted .recipe-title,
+.recipe-item.deleted .recipe-text,
+.recipe-item.deleted .recipe-url {
+  color: #777;
+  text-decoration: line-through;
+}
+
+.undelete-btn {
+  background: #28a745;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5em 1em;
+  cursor: pointer;
+  font-size: 0.9em;
+  margin-top: 0.5em;
+  transition: all 0.2s ease;
+  font-weight: 600;
+}
+
+.undelete-btn:hover {
+  background: #218838;
+  transform: translateY(-1px);
+}
+
+.edit-btn {
+  background: transparent;
+  color: #666;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  padding: 0.5em;
+  cursor: pointer;
+  font-size: 0.9em;
+  margin-top: 0.5em;
+  margin-right: 0.5em;
+  transition: all 0.2s ease;
+}
+
+.edit-btn:hover {
+  background: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.recipe-actions {
+  display: flex;
+  gap: 0.5em;
+  margin-top: 0.5em;
+}

--- a/src/api.js
+++ b/src/api.js
@@ -39,6 +39,19 @@ export async function softDeleteRecipe(secret, id) {
     return await res.json();
 }
 
+export async function undeleteRecipe(secret, id) {
+    const res = await fetch(`${WORKER_URL}/recipes/${id}`, {
+        method: 'PATCH',
+        headers: {
+            Authorization: secret,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ deleted: false }),
+    });
+    if (!res.ok) throw new Error('Failed to undelete recipe');
+    return await res.json();
+}
+
 export async function updateRecipe(secret, id, updates) {
     const res = await fetch(`${WORKER_URL}/recipes/${id}`, {
         method: 'PATCH',

--- a/src/api.test.js
+++ b/src/api.test.js
@@ -1,4 +1,4 @@
-import { fetchRecipes, addRecipe, softDeleteRecipe, updateRecipe } from './api'
+import { fetchRecipes, addRecipe, softDeleteRecipe, undeleteRecipe, updateRecipe } from './api'
 
 const WORKER_URL = 'https://jessipes-worker.12v.workers.dev'
 const mockSecret = 'test-secret'
@@ -170,6 +170,41 @@ describe('API Functions', () => {
       })
 
       await expect(softDeleteRecipe(mockSecret, recipeId)).rejects.toThrow('Failed to delete recipe')
+    })
+  })
+
+  describe('undeleteRecipe', () => {
+    test('undeletes recipe successfully', async () => {
+      const recipeId = 'recipe-123'
+      const expectedResponse = { id: recipeId, deleted: false }
+
+      global.fetch.mockResolvedValue({
+        ok: true,
+        json: async () => expectedResponse,
+      })
+
+      const result = await undeleteRecipe(mockSecret, recipeId)
+
+      expect(fetch).toHaveBeenCalledWith(`${WORKER_URL}/recipes/${recipeId}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: mockSecret,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ deleted: false }),
+      })
+      expect(result).toEqual(expectedResponse)
+    })
+
+    test('throws error when undelete fails', async () => {
+      const recipeId = 'recipe-123'
+
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+      })
+
+      await expect(undeleteRecipe(mockSecret, recipeId)).rejects.toThrow('Failed to undelete recipe')
     })
   })
 


### PR DESCRIPTION
This PR adds a screen to view and restore deleted recipes.

## Changes:
- Add toggle button to switch between active and deleted recipe views
- Implement undelete functionality to restore deleted recipes
- Add visual styling for deleted recipes (reduced opacity, strikethrough)
- Update filtering logic to show appropriate recipes based on view mode
- Add undeleteRecipe API function for restoration functionality

Resolves #5

Generated with [Claude Code](https://claude.ai/code)